### PR TITLE
Allow user to pass in Stats.js, not just an instance

### DIFF
--- a/src/StatJSAdapter.ts
+++ b/src/StatJSAdapter.ts
@@ -1,12 +1,12 @@
 namespace GStats{
 	export class StatsJSAdapter {
 		public stats:any;
+		public Stats:any;
 		public dcPanel?:any;
 		public tcPanel?:any;
 		public hook:BaseHooks;
 
-		constructor(_hook:BaseHooks, _stats?:any) {
-			
+		constructor(_hook:BaseHooks, _stats?:any, _Stats?:any) {
 			this.hook = _hook;
 
 			if(_stats){
@@ -22,9 +22,22 @@ namespace GStats{
 
 			}
 
+			if(_Stats){
+			
+				this.Stats = _Stats;
+			
+			}else {
+
+				this.Stats = null;				
+				if((window as any).Stats){
+					this.stats = (window as any).Stats;
+				}
+
+			}
+
 			if(this.stats){
-				this.dcPanel =  this.stats.addPanel(new (window as any).Stats.Panel("DC:", "#330570","#A69700"));
-				this.tcPanel =  this.stats.addPanel(new (window as any).Stats.Panel("TC:", "#A62500","#00B454"));
+				this.dcPanel = this.stats.addPanel(this.Stats.Panel("DC:", "#330570","#A69700"));
+				this.tcPanel = this.stats.addPanel(this.Stats.Panel("TC:", "#A62500","#00B454"));
 				this.stats.showPanel(0);
 			} else {
 				console.error("Stats can't found in window, pass instance of Stats.js as second param");


### PR DESCRIPTION
Currently, StatJSAdapter still try window.Stats when creating the panels, even if it doesn't exist. To fix this you would need to be able to pass in the whole of Stats.js, not just an instance of it.